### PR TITLE
LAMBDA-57537 Use non-deprecated apex run command instead of sfdx:force:apex:execute

### DIFF
--- a/src/utils/sfdx.js
+++ b/src/utils/sfdx.js
@@ -260,7 +260,7 @@ let dataFactory = function (deploy) {
   core.info('=== dataFactory ===');
   if (deploy.dataFactory && !deploy.checkonly) {
     core.info('Executing data factory');
-    execCommand.run(SFDX, ['force:apex:execute', '-f', deploy.dataFactory, '-u', deploy.username]);
+    execCommand.run(SFDX, ['apex', 'run', '-f', deploy.dataFactory, '-o', deploy.username]);
   }
 };
 


### PR DESCRIPTION
* Use non-deprecated apex run command instead of sfdx:force:apex:execute